### PR TITLE
[python3-yaml] update to 5.4.1.1. Contributes to JB#58954

### DIFF
--- a/rpm/python3-yaml.spec
+++ b/rpm/python3-yaml.spec
@@ -1,6 +1,6 @@
 Name:       python3-yaml
 Summary:    YAML parser and emitter for Python
-Version:    5.3
+Version:    5.4.1.1
 Release:    1
 License:    MIT
 URL:        http://pyyaml.org/

--- a/rpm/python3-yaml.spec
+++ b/rpm/python3-yaml.spec
@@ -7,6 +7,9 @@ URL:        http://pyyaml.org/
 Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+# do not use internal yaml implementation
+BuildRequires:  pkgconfig(yaml-0.1)
+BuildRequires:  python3dist(cython)
 Provides:       PyYAML
 
 %description


### PR DESCRIPTION
There are three possible update candidates for this package:

  - 5.3.1: the most conservative change, mainly a security fix [link to changes](https://github.com/yaml/pyyaml/compare/5.3...5.3.1)
  - 5.4.1(.1): some changes and another CVE fix [link to changes](https://github.com/yaml/pyyaml/compare/5.3...5.4.1.1)
  - 6.0: latest released version [link to changes](https://github.com/yaml/pyyaml/compare/5.3...6.0)

The fork this PR originates from has branches implementing a bump for each of those. 5.4 is proposed here as a middle ground between conservative bump and security fixes gained.

For testing packages are available for each of these: https://build.merproject.org/project/show/home:nephros:sailfishos:python

The main motivation for this PR is the ability to bump the 'yq' tool (in chum) to a more recent version - which requires pyyaml >= 3.5.1.  
Due to the "don't ship packages which replace system packages" agreement on Chum, we can't bump pyyaml there.

The only user of this package I am aware of is the spectacle tool, which works fine with 5.4.x, but there might be others to test.
